### PR TITLE
Init Integration Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,4 +4,5 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - run: cd test && make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,7 @@
+name: test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cd test && make test

--- a/encoding.go
+++ b/encoding.go
@@ -1,0 +1,34 @@
+package usftp
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+func Uint32(b []byte) (uint32, []byte) {
+	v := binary.BigEndian.Uint32(b)
+	return v, b[4:]
+}
+
+func Uint64(b []byte) (uint64, []byte) {
+	v := binary.BigEndian.Uint64(b)
+	return v, b[8:]
+}
+
+func String(b []byte) (string, []byte) {
+	l, b := Uint32(b)
+	return string(b[0:l]), b[l:]
+}
+
+func WriteUint32(w io.Writer, v uint32) error {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, v)
+	_, err := w.Write(b)
+	return err
+}
+
+func WriteUint8(w io.Writer, v uint8) error {
+	b := []byte{v}
+	_, err := w.Write(b)
+	return err
+}

--- a/session.go
+++ b/session.go
@@ -17,7 +17,6 @@ type (
 		ctx    context.Context
 		cancel context.CancelFunc
 		seq    uint32
-		errors []error
 	}
 )
 
@@ -59,10 +58,6 @@ func NewSession(c *ssh.Client) (*Session, error) {
 
 	err = s.init()
 	return s, err
-}
-
-func (s *Session) Errors() []error {
-	return s.errors
 }
 
 func (s *Session) Close() error {

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,18 +1,4 @@
-.PHONY: run sshkey up down tests test
+.PHONY: test
 
-test: sshkey down up tests down
-
-sshkey:
-	rm ssh_key ssh_key.pub  || true
-	ssh-keygen -t rsa -b 4096 -f ssh_key -P ""
-
-up: sshkey
-	docker compose up -d
-
-down:
-	docker compose down -v || true
-
-tests:
-	go test -v ./...
-
-
+test:
+	bash test.sh

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,6 @@
-.PHONY: run sshkey up down
+.PHONY: run sshkey up down tests test
+
+test: sshkey down up tests down
 
 sshkey:
 	rm ssh_key ssh_key.pub  || true
@@ -8,9 +10,9 @@ up: sshkey
 	docker compose up -d
 
 down:
-	docker compose down -v
+	docker compose down -v || true
 
-test:
-	go test ./...
+tests:
+	go test -v ./...
 
-run: sshkey up test down
+

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   sftp-server:
     image: "atmoz/sftp:alpine"

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set +e
+set -x
+rm ssh_key ssh_key.pub  || true
+ssh-keygen -t rsa -b 4096 -f ssh_key -P ""
+docker compose down -v || true
+docker compose up -d
+go test -v ./...
+S=$?
+docker compose down -v || true
+rm ssh_key ssh_key.pub  || true
+exit $S

--- a/test/usftp_test.go
+++ b/test/usftp_test.go
@@ -39,7 +39,8 @@ func Test_Ls(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(names) != 4 {
-		t.Errorf("got %d names, expected 4", len(names))
+	expected := 4
+	if len(names) != expected {
+		t.Errorf("got %d names, expected %d", len(names), expected)
 	}
 }

--- a/test/usftp_test.go
+++ b/test/usftp_test.go
@@ -39,5 +39,7 @@ func Test_Ls(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = names
+	if len(names) != 4 {
+		t.Errorf("got %d names, expected 4", len(names))
+	}
 }

--- a/writer.go
+++ b/writer.go
@@ -2,7 +2,6 @@ package usftp
 
 import (
 	"bytes"
-	"encoding/binary"
 	"io"
 )
 
@@ -19,14 +18,14 @@ func (w *writer) write(m Msg) error {
 		return err
 	}
 	l := uint32(len(payload)) + 1
-	if err := binary.Write(buf, binary.BigEndian, l); err != nil {
+	if err := WriteUint32(buf, l); err != nil {
 		return err
 	}
 	t, err := TypeId(m)
 	if err != nil {
 		return err
 	}
-	if err := binary.Write(buf, binary.BigEndian, t); err != nil {
+	if err := WriteUint8(buf, t); err != nil {
 		return err
 	}
 	buf.Write(payload)


### PR DESCRIPTION
Adds a test.sh and make test target in the test folder. `make test` runs a third party sftp server with generated ssh keys for a `foo` user via docker compose. It then runs integration tests via go test. Finally finishes up with a compose down and the removal of the generated ssh keys. 