### PR TITLE
FileMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# USFTP
+
+An SFTP client library with minimal dependencies.
+
+With reference to https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02

--- a/filemode.go
+++ b/filemode.go
@@ -1,0 +1,39 @@
+package usftp
+
+// FileMode is a partial implementation of FileMode as the std lib implementation is not
+// compatible for reasons I am yet to fully understand
+type FileMode uint32
+
+const (
+	ModeType    = 0xF000
+	ModeDir     = 0x4000
+	ModeRegular = 0x8000
+)
+
+func (m FileMode) String() string {
+	b := make([]byte, 10)
+	switch m & ModeType {
+	case ModeDir:
+		b[0] = 'd'
+	case ModeRegular:
+		b[0] = '-'
+	}
+
+	const rwx = "rwxrwxrwx"
+	for i, c := range rwx {
+		if m&(1<<uint(9-1-i)) != 0 {
+			b[i+1] = byte(c)
+		} else {
+			b[i+1] = '-'
+		}
+	}
+	return string(b)
+}
+
+func (m FileMode) IsDir() bool {
+	return (m & ModeType) == ModeDir
+}
+
+func (m FileMode) IsRegular() bool {
+	return (m & ModeType) == ModeRegular
+}

--- a/packet.go
+++ b/packet.go
@@ -189,7 +189,7 @@ type (
 		Size          uint64
 		Uid           uint32
 		Gid           uint32
-		Permissions   uint32
+		Permissions   FileMode
 		Atime         uint32
 		Mtime         uint32
 		ExtendedCount uint32
@@ -330,7 +330,7 @@ func (r *NameResp) UnmarshalBinary(b []byte) error {
 	r.Id, b = Uint32(b)
 	r.Count, b = Uint32(b)
 	var flags uint32
-	
+
 	for i := uint32(0); i < r.Count; i++ {
 		v := NameRespFile{}
 		v.Filename, b = String(b)
@@ -344,7 +344,9 @@ func (r *NameResp) UnmarshalBinary(b []byte) error {
 			v.Attrs.Gid, b = Uint32(b)
 		}
 		if flags&SSH_FILEXFER_ATTR_PERMISSIONS != 0 {
-			v.Attrs.Permissions, b = Uint32(b)
+			var p uint32
+			p, b = Uint32(b)
+			v.Attrs.Permissions = FileMode(p)
 		}
 		if flags&SSH_FILEXFER_ATTR_ACMODTIME != 0 {
 			v.Attrs.Atime, b = Uint32(b)
@@ -359,9 +361,9 @@ func (r *NameResp) UnmarshalBinary(b []byte) error {
 
 		r.Names = append(r.Names, v)
 	}
-
 	return nil
 }
+
 func (r *NameResp) MarshalBinary() ([]byte, error) {
 	return nil, nil
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,3 +2,13 @@
 
 test:
 	bash test.sh
+
+test-setup:
+	rm ssh_key ssh_key.pub  || true
+	ssh-keygen -t rsa -b 4096 -f ssh_key -P ""
+	docker compose down -v || true
+	docker compose up -d
+
+test-setdown:
+	docker compose up -d || true
+	rm ssh_key ssh_key.pub  || true

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 set +e
 set -x
-rm ssh_key ssh_key.pub  || true
-ssh-keygen -t rsa -b 4096 -f ssh_key -P ""
-docker compose down -v || true
-docker compose up -d
+make test-setup
 go test -v ./...
 S=$?
-docker compose down -v || true
-rm ssh_key ssh_key.pub  || true
+make test-setdown
 exit $S

--- a/test/usftp_test.go
+++ b/test/usftp_test.go
@@ -53,6 +53,9 @@ func Test_Ls(t *testing.T) {
 	if !m["."].IsDir() {
 		t.Errorf("expected . to be a directory")
 	}
+	if m["."].IsRegular() {
+		t.Errorf("expected . to be a directory")
+	}
 
 	actual := m["."].String()
 	expected := "drwxr-xr-x"
@@ -61,6 +64,9 @@ func Test_Ls(t *testing.T) {
 	}
 
 	if m["file.txt"].IsDir() {
+		t.Errorf("expected file.txt to be a file")
+	}
+	if !m["file.txt"].IsRegular() {
 		t.Errorf("expected file.txt to be a file")
 	}
 }

--- a/test/usftp_test.go
+++ b/test/usftp_test.go
@@ -63,10 +63,10 @@ func Test_Ls(t *testing.T) {
 		t.Errorf("got %s, expected %s", actual, expected)
 	}
 
-	if m["file.txt"].IsDir() {
+	if (m["file1.txt"]).IsDir() {
 		t.Errorf("expected file.txt to be a file")
 	}
-	if !m["file.txt"].IsRegular() {
+	if !(m["file1.txt"]).IsRegular() {
 		t.Errorf("expected file.txt to be a file")
 	}
 }

--- a/test/usftp_test.go
+++ b/test/usftp_test.go
@@ -39,8 +39,28 @@ func Test_Ls(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := 4
-	if len(names) != expected {
-		t.Errorf("got %d names, expected %d", len(names), expected)
+	{
+		expected := 4
+		if len(names) != expected {
+			t.Errorf("got %d names, expected %d", len(names), expected)
+		}
+	}
+
+	m := make(map[string]usftp.FileMode)
+	for _, name := range names {
+		m[name.Filename] = name.Attrs.Permissions
+	}
+	if !m["."].IsDir() {
+		t.Errorf("expected . to be a directory")
+	}
+
+	actual := m["."].String()
+	expected := "drwxr-xr-x"
+	if actual != expected {
+		t.Errorf("got %s, expected %s", actual, expected)
+	}
+
+	if m["file.txt"].IsDir() {
+		t.Errorf("expected file.txt to be a file")
 	}
 }


### PR DESCRIPTION
fs.FileMode masks do not work directly with the permissions returned in Attrs. Init a custom FileMode which does work. This allows to correctly identify directories from regular files. 