### PR TITLE
Init Readfile

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -20,6 +20,13 @@ func String(b []byte) (string, []byte) {
 	return string(b[0:l]), b[l:]
 }
 
+func WriteUint64(w io.Writer, v uint64) error {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	_, err := w.Write(b)
+	return err
+}
+
 func WriteUint32(w io.Writer, v uint32) error {
 	b := make([]byte, 4)
 	binary.BigEndian.PutUint32(b, v)
@@ -30,5 +37,13 @@ func WriteUint32(w io.Writer, v uint32) error {
 func WriteUint8(w io.Writer, v uint8) error {
 	b := []byte{v}
 	_, err := w.Write(b)
+	return err
+}
+
+func WriteString(w io.Writer, v string) error {
+	if err := WriteUint32(w, uint32(len(v))); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte(v))
 	return err
 }

--- a/session.go
+++ b/session.go
@@ -2,10 +2,10 @@ package usftp
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/sync/errgroup"
+	"io"
 	"sync/atomic"
 )
 
@@ -87,6 +87,98 @@ func (s *Session) init() error {
 	return nil
 }
 
+func (s *Session) Get(from string, out io.Writer) error {
+	id := s.nextSeq()
+	read := s.r.getChan(id)
+	defer s.r.delChan(id)
+	handle, err := s.OpenReq(id, read, from)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = s.CloseReq(id, read, handle) }()
+	// how much to read at a time ?
+	//
+	// https://github.com/openssh/openssh-portable/blob/master/sftp-common.h#L29
+	// /* Maximum packet that we are willing to send/accept */
+	//    #define SFTP_MAX_MSG_LENGTH	(256 * 1024)
+	cont := true
+	offset := uint64(0)
+	len := uint32(10 * 1024)
+	for cont {
+		b, err := s.ReadReq(id, read, handle, offset, len)
+		if err != nil {
+			if err == io.EOF {
+				cont = false
+			} else {
+				return err
+			}
+		}
+		_, err = out.Write(b)
+		if err != nil {
+			return err
+		}
+		offset += uint64(len)
+	}
+
+	return nil
+}
+
+func (s *Session) ReadReq(id uint32, read chan Msg, handle string, offset uint64, len uint32) ([]byte, error) {
+	if err := s.w.write(&ReadReq{Header: Header{Id: id}, Handle: handle, Offset: offset, Len: len}); err != nil {
+		return nil, err
+	}
+	msg := <-read
+	switch msg := msg.(type) {
+	case *DataResp:
+		return msg.Data, nil
+	case *StatusResp:
+		if msg.ErrorCode == SSH_FX_EOF {
+			return nil, io.EOF
+		}
+		if msg.ErrorCode == SSH_FX_OK {
+			return nil, io.EOF
+		} else {
+			return nil, fmt.Errorf("error: %s", msg.ErrorMessage)
+		}
+	default:
+		return nil, fmt.Errorf("unhandled message type %T", msg)
+	}
+}
+
+func (s *Session) CloseReq(id uint32, read chan Msg, handle string) error {
+	if err := s.w.write(&CloseReq{Header: Header{Id: id}, Handle: handle}); err != nil {
+		return err
+	}
+	msg := <-read
+	switch msg := msg.(type) {
+	case *StatusResp:
+		if msg.ErrorCode != SSH_FX_OK {
+			// there is an error, but is it really our problem ?
+		}
+	default:
+		return fmt.Errorf("unhandled message type %T", msg)
+	}
+	return nil
+}
+
+func (s *Session) OpenReq(id uint32, read chan Msg, path string) (string, error) {
+	if err := s.w.write(&OpenReq{Header: Header{Id: id}, Filename: path, Pflags: SSH_FXF_READ}); err != nil {
+		return "", err
+	}
+	msg := <-read
+	var handle string
+	handleResp, statusResp, err := s.handleOrStatusResp(msg)
+	switch true {
+	case err != nil:
+		return "", err
+	case handleResp != nil:
+		handle = handleResp.Handle
+	case statusResp != nil:
+		return "", fmt.Errorf("error: %s", statusResp.ErrorMessage)
+	}
+	return handle, nil
+}
+
 func (s *Session) Ls(path string) ([]NameRespFile, error) {
 	var names []NameRespFile
 	id := s.nextSeq()
@@ -95,52 +187,73 @@ func (s *Session) Ls(path string) ([]NameRespFile, error) {
 	if err := s.w.write(&OpenDirReq{Header: Header{Id: id}, Path: path}); err != nil {
 		return nil, err
 	}
-	var handle string
 	msg := <-read
-	// expect SSH_FXP_HANDLE or SSH_FXP_STATUS response
-	switch msg := msg.(type) {
-	case *HandleResp:
-		handle = msg.Handle
-	case *StatusResp:
-		return nil, fmt.Errorf("error: %s", msg.ErrorMessage)
-	default:
-		return nil, errors.New("unhandled")
+	var handle string
+	handleResp, statusResp, err := s.handleOrStatusResp(msg)
+	switch true {
+	case err != nil:
+		return nil, err
+	case handleResp != nil:
+		handle = handleResp.Handle
+	case statusResp != nil:
+		return nil, fmt.Errorf("error: %s", statusResp.ErrorMessage)
 	}
 	cont := true
 	for cont {
-		if err := s.w.write(&ReadDirReq{Header: Header{Id: id}, Handle: handle}); err != nil {
+		nameResp, statusResp, err := s.readDirReq(id, read, handle)
+		switch true {
+		case err != nil:
 			return nil, err
-		}
-		msg = <-read
-		// expect SSH_FXP_NAME or SSH_FXP_STATUS response
-		switch msg := msg.(type) {
-		case *NameResp:
-			names = append(names, msg.Names...)
-		case *StatusResp:
-			if msg.ErrorCode == SSH_FX_EOF {
+		case nameResp != nil:
+			names = append(names, nameResp.Names...)
+		case statusResp != nil:
+			if statusResp.ErrorCode == SSH_FX_EOF {
 				cont = false
 				continue
 			}
-			return nil, fmt.Errorf("error: %s", msg.ErrorMessage)
-		default:
-			return nil, errors.New("unhandled")
+			return nil, fmt.Errorf("error: %s", statusResp.ErrorMessage)
 		}
 	}
-	// SSH_FXP_CLOSE
-	if err := s.w.write(&CloseReq{Header: Header{Id: id}, Handle: handle}); err != nil {
-		return nil, err
-	}
-	msg = <-read
-
-	// expect SSH_FXP_STATUS
-	switch msg := msg.(type) {
-	case *StatusResp:
-		if msg.ErrorCode != SSH_FX_OK {
-			// there is an error, but is it really our problem ?
-		}
-	default:
-		return nil, errors.New("unhandled")
-	}
-
+	_ = s.CloseReq(id, read, handle)
 	return names, nil
+}
+
+func (s *Session) readDirReq(id uint32, read chan Msg, handle string) (*NameResp, *StatusResp, error) {
+	if err := s.w.write(&ReadDirReq{Header: Header{Id: id}, Handle: handle}); err != nil {
+		return nil, nil, err
+	}
+	msg := <-read
+	nameResp, statusResp, err := s.nameOrStatusResp(msg)
+	switch true {
+	case err != nil:
+		return nil, nil, err
+	case nameResp != nil:
+		return nameResp, nil, nil
+	case statusResp != nil:
+		return nil, statusResp, nil
+	default:
+		return nil, nil, fmt.Errorf("unhandled message type %T", msg)
+	}
+}
+
+func (s *Session) nameOrStatusResp(msg Msg) (*NameResp, *StatusResp, error) {
+	switch msg := msg.(type) {
+	case *NameResp:
+		return msg, nil, nil
+	case *StatusResp:
+		return nil, msg, nil
+	default:
+		return nil, nil, fmt.Errorf("unhandled message type %T", msg)
+	}
+}
+
+func (s *Session) handleOrStatusResp(msg Msg) (*HandleResp, *StatusResp, error) {
+	switch msg := msg.(type) {
+	case *HandleResp:
+		return msg, nil, nil
+	case *StatusResp:
+		return nil, msg, nil
+	default:
+		return nil, nil, fmt.Errorf("unhandled message type %T", msg)
+	}
 }

--- a/test/usftp_test.go
+++ b/test/usftp_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bytes"
 	"github.com/richardjennings/usftp"
 	"golang.org/x/crypto/ssh"
 	"testing"
@@ -68,5 +69,23 @@ func Test_Ls(t *testing.T) {
 	}
 	if !(m["file1.txt"]).IsRegular() {
 		t.Errorf("expected file.txt to be a file")
+	}
+}
+
+func Test_Get(t *testing.T) {
+	c := clientHelper(t)
+	defer func() { _ = c.Close() }()
+	s, err := usftp.NewSession(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+
+	w := bytes.NewBuffer(nil)
+	if err := s.Get("/share/file1.txt", w); err != nil {
+		t.Fatal(err)
+	}
+	if w.String() != "a" {
+		t.Errorf("got %q, expected %q", w.String(), "a")
 	}
 }


### PR DESCRIPTION
Initial implementation of reading a file from an SFTP server and writing to an `io.writer`

Open file to get a handle

Read file from up to offset to Len bytes

Handle EOF

Close Handle

Tidbit around OpenSSH SFTP_MAX_MSG_LENGTH (256 * 1024)
https://github.com/openssh/openssh-portable/blob/master/sftp-common.h#L29


