### PR TITLE
UnseenFileVisitor to allow conditional directory traversal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/richardjennings/usftp
 go 1.24.5
 
 require (
-	golang.org/x/crypto v0.40.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/sys v0.34.0 // indirect
+	golang.org/x/crypto v0.40.0
+	golang.org/x/sync v0.16.0
 )
+
+require golang.org/x/sys v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
 golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.33.0 h1:NuFncQrRcaRvVmgRkvM3j/F00gWIAlcmlB8ACEKmGIg=
+golang.org/x/term v0.33.0/go.mod h1:s18+ql9tYWp1IfpV9DmCtQDDSRBUjKaw9M1eAv5UeF0=

--- a/packet.go
+++ b/packet.go
@@ -205,8 +205,10 @@ type (
 	NameRespFile struct {
 		Filename string
 		Longname string
-		Children []*NameRespFile
 		Attrs    Attrs
+
+		Path     string
+		Children []*NameRespFile
 	}
 	CloseReq struct {
 		Header
@@ -302,7 +304,7 @@ func (h Header) id() uint32 {
 }
 
 func (i *InitReq) UnmarshalBinary(b []byte) error {
-	i.Version, b = Uint32(b)
+	i.Version, _ = Uint32(b)
 	return nil
 }
 func (i *InitReq) MarshalBinary() ([]byte, error) {
@@ -314,7 +316,7 @@ func (i *InitReq) MarshalBinary() ([]byte, error) {
 }
 
 func (v *VersionResp) UnmarshalBinary(b []byte) error {
-	v.Version, b = Uint32(b)
+	v.Version, _ = Uint32(b)
 	return nil
 }
 func (v *VersionResp) MarshalBinary() ([]byte, error) {
@@ -353,7 +355,7 @@ func (r *ReadDirReq) MarshalBinary() ([]byte, error) {
 
 func (r *HandleResp) UnmarshalBinary(b []byte) error {
 	r.Id, b = Uint32(b)
-	r.Handle, b = String(b)
+	r.Handle, _ = String(b)
 	return nil
 }
 func (r *HandleResp) MarshalBinary() ([]byte, error) {
@@ -377,7 +379,7 @@ func (r *CloseReq) MarshalBinary() ([]byte, error) {
 func (r *StatusResp) UnmarshalBinary(b []byte) error {
 	r.Id, b = Uint32(b)
 	r.ErrorCode, b = Uint32(b)
-	r.ErrorMessage, b = String(b)
+	r.ErrorMessage, _ = String(b)
 	return nil
 }
 func (r *StatusResp) MarshalBinary() ([]byte, error) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test
+.PHONY: test test-setup test-setdown
 
 test:
 	bash test.sh

--- a/visitor.go
+++ b/visitor.go
@@ -1,0 +1,41 @@
+package usftp
+
+import (
+	"path/filepath"
+)
+
+type (
+	Visitor interface {
+		Visit(file *NameRespFile) bool
+		Files() []*NameRespFile
+	}
+
+	UnseenFileVisitor struct {
+		exclude []string
+		seen    map[string]*NameRespFile
+		found   []*NameRespFile
+	}
+)
+
+func NewUnseenFileVisitor(seen map[string]*NameRespFile, exclude []string) *UnseenFileVisitor {
+	return &UnseenFileVisitor{seen: seen, exclude: exclude}
+}
+func (u *UnseenFileVisitor) Files() []*NameRespFile {
+	return u.found
+}
+
+func (u *UnseenFileVisitor) Visit(file *NameRespFile) bool {
+	fn := filepath.Join(file.Path, file.Filename)
+	for _, v := range u.exclude {
+		if fn == v {
+			return false
+		}
+	}
+	if _, ok := u.seen[fn]; ok {
+		if u.seen[fn].Attrs.Size == file.Attrs.Size {
+			return false
+		}
+	}
+	u.found = append(u.found, file)
+	return true
+}


### PR DESCRIPTION
UnseenFileVisitor to allow conditional directory traversal. Specify previous seen and files to exclude. Returning   `true` from the Visitor halts the recursive directory traversal.